### PR TITLE
build.yml: fix lpi4a build,remove all UART driver from extra config

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,6 +94,11 @@ jobs:
               cat config >> arch/riscv/configs/${{ matrix.kernel_config }}
             fi
             
+            # fix lpi4a
+            if [[ ${{ matrix.board }} = 'th1520' ]]; then
+              sed -i '/UART/d' ../common_driver_defconfig
+            fi
+            
             # fix drivers
             cat ../common_driver_defconfig >> arch/riscv/configs/${{ matrix.kernel_config }}
 


### PR DESCRIPTION
build.yml: fix lpi4a build,remove all UART driver from common driver defconfig in lpi4a 
fix commit feat: add lpi4a kernel #171
    Link:https://github.com/deepin-community/deepin-riscv-kernel/commit/d77f07722a1c43590e1d3c6e0c8a473099db4881
    reason: to support lpi4a board
    The SDK import BT_HCIUART_RTL3WIRE 
    The realtek SDK port break other UART bt driver in the tree.
    Many people use pcie/m.2 wifi module and the inboard 
    bluetooth use usb bt driver not uart bt driver.
    If we have reason to support bt driver in lpi4a,we need to 
    fix in this SDK.
  CC [M]  drivers/bluetooth/hci_bcsp.o
drivers/bluetooth/hci_bcsp.c:761:10: error: ‘const struct hci_uart_proto’ has no member named ‘name’
  761 |         .name           = "BCSP",
      |          ^~~~
drivers/bluetooth/hci_bcsp.c:761:27: error: initialization of ‘int (*)(struct hci_uart *)’ from incompatible pointer type ‘char *’ [-Werror=incompatible-pointer-types]
  761 |         .name           = "BCSP",
      |                           ^~~~~~
drivers/bluetooth/hci_bcsp.c:761:27: note: (near initialization for ‘bcsp.open’)
drivers/bluetooth/hci_bcsp.c:766:27: error: initialization of ‘int (*)(struct hci_uart *, void *, int)’ from incompatible pointer type ‘int (*)(struct hci_uart *, const void *, int)’ [-Werror=incompatible-pointer-types]
  766 |         .recv           = bcsp_recv,
      |                           ^~~~~~~~~
drivers/bluetooth/hci_bcsp.c:766:27: note: (near initialization for ‘bcsp.recv’)
drivers/bluetooth/hci_bcsp.c: In function ‘bcsp_init’:
drivers/bluetooth/hci_bcsp.c:772:40: warning: passing argument 1 of ‘hci_uart_register_proto’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
  772 |         return hci_uart_register_proto(&bcsp);
      |                                        ^~~~~
In file included from drivers/bluetooth/hci_bcsp.c:33:
drivers/bluetooth/hci_uart.h:124:59: note: expected ‘struct hci_uart_proto *’ but argument is of type ‘const struct hci_uart_proto *’
  124 | extern int hci_uart_register_proto(struct hci_uart_proto *p);
      |                                    ~~~~~~~~~~~~~~~~~~~~~~~^
drivers/bluetooth/hci_bcsp.c: In function ‘bcsp_deinit’:
drivers/bluetooth/hci_bcsp.c:777:42: warning: passing argument 1 of ‘hci_uart_unregister_proto’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
  777 |         return hci_uart_unregister_proto(&bcsp);
      |                                          ^~~~~
drivers/bluetooth/hci_uart.h:125:61: note: expected ‘struct hci_uart_proto *’ but argument is of type ‘const struct hci_uart_proto *’
  125 | extern int hci_uart_unregister_proto(struct hci_uart_proto *p);
      |                                      ~~~~~~~~~~~~~~~~~~~~~~~^
cc1: some warnings being treated as errors