### PR TITLE
fix(build.yml): move apt update before free disk

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,6 +57,10 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
+      - name: "Update APT sources"
+        run: |
+          sudo apt update
+
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@main
         with:
@@ -75,7 +79,6 @@ jobs:
       - uses: actions/checkout@v3
       - name: "Install Deps"
         run: |
-          sudo apt update
           sudo apt install -y gdisk dosfstools g++-12-riscv64-linux-gnu build-essential \
                         libncurses-dev gawk flex bison openssl libssl-dev \
                         dkms libelf-dev pahole libudev-dev libpci-dev libiberty-dev autoconf mkbootimg \


### PR DESCRIPTION
fix ci build error:
https://github.com/deepin-community/deepin-riscv-kernel/actions/runs/5538431736 After this operation, 990 MB disk space will be freed. Ign:1 http://azure.archive.ubuntu.com/ubuntu jammy-updates/universe amd64 aspnetcore-targeting-pack-6.0 amd64 6.0.119-0ubuntu1~22.04.1 Ign:2 http://azure.archive.ubuntu.com/ubuntu jammy-updates/universe amd64 aspnetcore-targeting-pack-7.0 amd64 7.0.108-0ubuntu1~22.04.1 Err:1 http://azure.archive.ubuntu.com/ubuntu jammy-updates/universe amd64 aspnetcore-targeting-pack-6.0 amd64 6.0.119-0ubuntu1~22.04.1
  404  Not Found [IP: 52.252.75.106 80]
Err:2 http://azure.archive.ubuntu.com/ubuntu jammy-updates/universe amd64 aspnetcore-targeting-pack-7.0 amd64 7.0.108-0ubuntu1~22.04.1
  404  Not Found [IP: 52.252.75.106 80]
E: Failed to fetch http://azure.archive.ubuntu.com/ubuntu/pool/universe/d/dotnet6/aspnetcore-targeting-pack-6.0_6.0.119-0ubuntu1%7e22.04.1_amd64.deb  404  Not Found [IP: 52.252.75.106 80] E: Failed to fetch http://azure.archive.ubuntu.com/ubuntu/pool/universe/d/dotnet7/aspnetcore-targeting-pack-7.0_7.0.108-0ubuntu1%7e22.04.1_amd64.deb  404  Not Found [IP: 52.252.75.106 80] E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing