### PR TITLE
fix: build error use pahole=1.25-0ubuntu1~22.04.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,7 +81,7 @@ jobs:
         run: |
           sudo apt install -y gdisk dosfstools g++-12-riscv64-linux-gnu build-essential \
                         libncurses-dev gawk flex bison openssl libssl-dev \
-                        dkms libelf-dev pahole libudev-dev libpci-dev libiberty-dev autoconf mkbootimg \
+                        dkms libelf-dev pahole=1.22-8 libudev-dev libpci-dev libiberty-dev autoconf mkbootimg \
                         fakeroot genext2fs genisoimage libconfuse-dev mtd-utils mtools qemu-utils qemu-utils squashfs-tools \
                         device-tree-compiler rauc simg2img u-boot-tools f2fs-tools arm-trusted-firmware-tools swig ccache debhelper
 


### PR DESCRIPTION
A hack: recover build dep vers.

lpi4a kernel build log in [3]:
FAILED: load BTF from vmlinux: Unknown error -22
make[3]: *** [Makefile:1278: vmlinux] Error 255

The main diff is ver between pahole 1.22-8 and 1.25-0ubuntu1~22.04.2.

Also try to add 4gb swap in
https://github.com/opsiff/deepin-riscv-kernel/pull/4 or try to build without ccache storage
https://github.com/opsiff/deepin-riscv-kernel/pull/6
 
Link:
1.https://github.com/deepin-community/deepin-riscv-kernel/actions/runs/5687475929/job/15415902378 2.https://github.com/deepin-community/deepin-riscv-kernel/actions/runs/5675769602/job/15381477447 3.https://github.com/deepin-community/deepin-riscv-kernel/actions/runs/5709859515/job/15469235995