### PR TITLE
chore: revert fix: build error use pahole=1.25-0ubuntu1~22.04.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,7 +81,7 @@ jobs:
         run: |
           sudo apt install -y gdisk dosfstools g++-12-riscv64-linux-gnu build-essential \
                         libncurses-dev gawk flex bison openssl libssl-dev \
-                        dkms libelf-dev pahole=1.22-8 libudev-dev libpci-dev libiberty-dev autoconf mkbootimg \
+                        dkms libelf-dev pahole libudev-dev libpci-dev libiberty-dev autoconf mkbootimg \
                         fakeroot genext2fs genisoimage libconfuse-dev mtd-utils mtools qemu-utils qemu-utils squashfs-tools \
                         device-tree-compiler rauc simg2img u-boot-tools f2fs-tools arm-trusted-firmware-tools swig ccache debhelper
 


### PR DESCRIPTION
After pr https://github.com/revyos/thead-kernel/pull/29 

[commit https://github.com/revyos/thead-kernel/commit/a26b2d282c4dc1b19f1015df5817d524d604a90e] 

the hack is not usable and may block autofix for pahole and another.