### PR TITLE
chore: clean up qemu-utils f2fs-tools arm-trusted-firmware-tools

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,8 +82,8 @@ jobs:
           sudo apt install -y gdisk dosfstools g++-12-riscv64-linux-gnu build-essential \
                         libncurses-dev gawk flex bison openssl libssl-dev \
                         dkms libelf-dev pahole libudev-dev libpci-dev libiberty-dev autoconf mkbootimg \
-                        fakeroot genext2fs genisoimage libconfuse-dev mtd-utils mtools qemu-utils qemu-utils squashfs-tools \
-                        device-tree-compiler rauc simg2img u-boot-tools f2fs-tools arm-trusted-firmware-tools swig ccache debhelper
+                        fakeroot genext2fs genisoimage libconfuse-dev mtd-utils mtools squashfs-tools \
+                        device-tree-compiler rauc simg2img u-boot-tools swig ccache debhelper
 
           sudo update-alternatives --install /usr/bin/riscv64-linux-gnu-gcc riscv64-gcc /usr/bin/riscv64-linux-gnu-gcc-12 10
           sudo update-alternatives --install /usr/bin/riscv64-linux-gnu-g++ riscv64-g++ /usr/bin/riscv64-linux-gnu-g++-12 10


### PR DESCRIPTION
The following deps 
"qemu-utils f2fs-tools arm-trusted-firmware-tools" are useless for the riscv kernel action now,
so try to remove from apt install.